### PR TITLE
Input section for cava config file

### DIFF
--- a/cava.sh
+++ b/cava.sh
@@ -17,6 +17,16 @@ echo "
 [general]
 bars = 10
 
+[input]
+method = pulse
+source = auto
+
+; method = pipewire
+; source = auto
+
+; method = alsa
+; source = hw:Loopback,1
+
 [output]
 method = raw
 raw_target = /dev/stdout


### PR DESCRIPTION
Ensures CAVA functions correctly by specifying the input method and source, as it won't work without this section